### PR TITLE
Use SECRET_KEY_BASE instead of DEVISE_SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,12 @@ bin/rake db:migrate db:seed
 bin/rake start
 ```
 
-Once you're ready to deploy to [Heroku](https://surge.sh), run:
+Once you're ready to deploy to [Heroku](https://www.heroku.com), run:
 
 ``` shell
 heroku apps:create
 heroku buildpacks:add heroku/nodejs --index 1
 heroku buildpacks:add heroku/ruby --index 2
-heroku config:set DEVISE_SECRET_KEY=A_VERY_LONG_STRING_OF_NUMBERS_AND_LETTERS
 git push heroku master
 heroku run rake db:seed
 heroku open

--- a/app.json
+++ b/app.json
@@ -11,12 +11,6 @@
   "scripts": {
     "postdeploy": "bundle exec rake db:seed"
   },
-  "env": {
-    "DEVISE_SECRET_KEY": {
-      "description": "Devise uses this key to generate random tokens. Changing this key will render invalid all existing confirmation, reset password and unlock tokens in the database.",
-      "generator": "secret"
-    }
-  },
   "addons": [
     "heroku-postgresql"
   ],

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  config.secret_key = ENV['DEVISE_SECRET_KEY'] if Rails.env.production?
+  # config.secret_key = ENV['DEVISE_SECRET_KEY'] if Rails.env.production?
   
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,8 @@
+development:
+  secret_key_base: 238648a936630627e432839869fa7d4f3b728f47664ecf2921d244a26830450d2c857ce80ab4dadfab0aa75fc70a38b869021101fc3665a8450f9ec635d97fff
+ 
+test:
+  secret_key_base: 4f0608da85354aac5eb3dc15203d298276179b35723a55b25106f25b342763855ba816b7fadccd079b6dcb4c62f19e0d39c1ee72fee2934c5779509f6ee537cc
+ 
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
The convention for >= Rails 4.1 is to use a `secrets.yml`.  See http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#config-secrets-yml for more details.