### PR TITLE
Fix undefined bug of drinks in Home

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -22,7 +22,7 @@ class Home extends Component {
   getDrinks () {
     this.fetch('/api/drinks')
       .then(drinks => {
-        if (drinks.length) {
+        if (drinks) {
           this.setState({drinks: drinks})
           this.getDrink(drinks[0].id)
         } else {


### PR DESCRIPTION
### Summary
Removed `.length`, from 'drinks.length' for fixing the bug.

### Context
[Cannot read property 'length' of undefined #11](https://github.com/heroku/list-of-ingredients/issues/11)




